### PR TITLE
UpdateEditMode fix

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -146,11 +146,14 @@ namespace MonoDevelop.SourceEditor
 		
 		void UpdateEditMode ()
 		{
-			if (TestNewViMode && !(CurrentMode is NewIdeViMode)) {
-				CurrentMode = new NewIdeViMode (this);
-			} else if (Options.UseViModes) {
-				if (!(CurrentMode is IdeViMode))
-					CurrentMode = new IdeViMode (this);
+			if (Options.UseViModes) {
+				if (TestNewViMode) {
+					if (!(CurrentMode is NewIdeViMode))
+					CurrentMode = new NewIdeViMode (this);
+				} else {
+					if (!(CurrentMode is IdeViMode))
+						CurrentMode = new IdeViMode (this);
+				}
 			} else {
 		//		if (!(CurrentMode is SimpleEditMode)){
 					SimpleEditMode simpleMode = new SimpleEditMode ();


### PR DESCRIPTION
Another inch of progress... It turns out I'm not crazy [1]

In my desperation, I sprinkled in two console trace messages It turns out that the mode selection gets wholly overruled, so I in fact end up with the old ViMode after all. [I haven't checked the reason why it did not appear to be a problem when debugging from within MonoDevelop.] Instead I fixed it in UpdateEditMode(), find it here

I found that the mode switch in response to ExtensibleTextEditor:OptionsChanged was flawed: it changes back to old vi mode if '[X] Use Vi modes' is selected in the options.

When toggling the '[ ] Use Vi modes' (unchecking it), ironically, we ended up with the new Vi mode :)

My fix assumes you want SimpleEditMode if the options checkbox is unchecked.

Cheers

[1] or at least not any more than I used to be
