### PR TITLE
Make it work without need for setting MONO_PATH by using a custom ..

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -927,6 +927,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					MonoDevelop.Core.Execution.RemotingService.RegisterRemotingChannel ();
 					var pinfo = new ProcessStartInfo (exe) {
+						Arguments = binDir,
 						WorkingDirectory = binDir,
 						UseShellExecute = false,
 						CreateNoWindow = true,
@@ -934,11 +935,6 @@ namespace MonoDevelop.Projects.MSBuild
 						RedirectStandardInput = true,
 					};
 					runtime.GetToolsExecutionEnvironment ().MergeTo (pinfo);
-
-					//HACK should instead pass binDir to the builder process and have it use a custom resolver
-					if (runtime is MonoTargetRuntime) {
-						pinfo.EnvironmentVariables ["MONO_PATH"] = binDir;
-					}
 
 					Process p = null;
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/Main.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/Main.cs
@@ -26,6 +26,8 @@
 using System;
 using System.IO;
 using System.Collections;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
@@ -38,28 +40,40 @@ namespace MonoDevelop.Projects.MSBuild
 	class MainClass
 	{
 		static readonly ManualResetEvent exitEvent = new ManualResetEvent (false);
+		static string msbuildBinDir = null;
 		
 		[STAThread]
-		public static void Main ()
+		public static void Main (string [] args)
 		{
 			try {
-				RegisterRemotingChannel ();
-				WatchProcess (Console.ReadLine ());
-				
-				var builderEngine = new BuildEngine ();
-				var bf = new BinaryFormatter ();
-				ObjRef oref = RemotingServices.Marshal (builderEngine);
-				var ms = new MemoryStream ();
-				bf.Serialize (ms, oref);
-				Console.Error.WriteLine ("[MonoDevelop]" + Convert.ToBase64String (ms.ToArray ()));
-				
-				if (WaitHandle.WaitAny (new WaitHandle[] { builderEngine.WaitHandle, exitEvent }) == 0) {
-					// Wait before exiting, so that the remote call that disposed the builder can be completed
-					Thread.Sleep (400);
+				if (args.Length > 0 && !String.IsNullOrEmpty (args [0])) {
+					// if we have a ("binDir") argument, then we want to build with
+					// OSS msbuild on OSX/Linux
+					msbuildBinDir = args [0];
+					AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler (MSBuildAssemblyResolver);
 				}
-				
+
+				Start ();
 			} catch (Exception ex) {
 				Console.WriteLine (ex);
+			}
+		}
+
+		static void Start()
+		{
+			RegisterRemotingChannel ();
+			WatchProcess (Console.ReadLine ());
+
+			var builderEngine = new BuildEngine ();
+			var bf = new BinaryFormatter ();
+			ObjRef oref = RemotingServices.Marshal (builderEngine);
+			var ms = new MemoryStream ();
+			bf.Serialize (ms, oref);
+			Console.Error.WriteLine ("[MonoDevelop]" + Convert.ToBase64String (ms.ToArray ()));
+
+			if (WaitHandle.WaitAny (new WaitHandle[] { builderEngine.WaitHandle, exitEvent }) == 0) {
+				// Wait before exiting, so that the remote call that disposed the builder can be completed
+				Thread.Sleep (400);
 			}
 		}
 		
@@ -96,6 +110,31 @@ namespace MonoDevelop.Projects.MSBuild
 			});
 			t.IsBackground = true;
 			t.Start ();
+		}
+
+		static Assembly MSBuildAssemblyResolver (object sender, ResolveEventArgs args)
+		{
+			// MSBuild 14.0 assemblies are being redirected to 14.1 assemblies,
+			// so we just need to look for 14.1 here
+			var msbuildAssembles = new string[] {
+							"Microsoft.Build",
+							"Microsoft.Build.Framework",
+							"Microsoft.Build.Tasks.Core",
+							"Microsoft.Build.Utilities.Core" };
+
+			var asmName = new AssemblyName (args.Name);
+			if (msbuildAssembles.Any (n => String.Compare (n, asmName.Name, StringComparison.InvariantCultureIgnoreCase) == 0)
+						&& asmName.Version < new Version (14, 1))
+				return null;
+
+			string fullPath = Path.Combine (msbuildBinDir, asmName.Name + ".dll");
+			if (File.Exists (fullPath)) {
+				// If the file exists under the msbuild bin dir, then we need
+				// to load it only from there. If that fails, then let that exception
+				// escape
+				return Assembly.LoadFrom (fullPath);
+			} else
+				return null;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.1.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.1.config
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+	<configSections>
+		<!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
+		<section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=14.1.0.0, Culture=neutral" />
+	</configSections>
 	<runtime>
 		<generatePublisherEvidence enabled="false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -11,6 +15,33 @@
 				<assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
 			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
+	<msbuildToolsets default="14.1">
+		<toolset toolsVersion="14.1">
+			<property name="MSBuildBinPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin" />
+			<property name="MSBuildToolsPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin" />
+			<property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
+			<msbuildExtensionsPathSearchPaths>
+				<searchPaths os="osx">
+					<property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+					<property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+					<property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+				</searchPaths>
+			</msbuildExtensionsPathSearchPaths>
+		</toolset>
+	</msbuildToolsets>
+
 </configuration>


### PR DESCRIPTION
.. assembly resolver.

- Also, set `MSBuildBinPath` and `MSBuildToolsPath`
in the app.config file for the builder.
- And set binding redirects for all MSBuild assemblies (>4.0) to the new
  14.1 assemblies